### PR TITLE
Optimize stack usage of Dispatch::poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Optimize stack usage of `Dispatch::poll`
 
 ## [0.1.1] - 2022-08-22
 - adjust to `interchange` API change


### PR DESCRIPTION
`Dispatch::poll` has to copy the request so that the app can write the response to the interchange.  Previously, we called `Responder::take_request` to obtain the message out of the interchange. This implementation had a stack usage of 15280 bytes while the message size is only 7609 bytes.

With this patch, we only request a reference from the responder and manually copy the message to a buffer.  This reduces the stack size to 7664 bytes.


I have no idea why the `take_request` implementation creates an additional copy of the message.  But as this function is the root for all CTAPHID commands, this means we can save around 7 kB stack virtually everywhere. Similar optimizations may be possible in other functions too.